### PR TITLE
Add options to form instead using of array mangling

### DIFF
--- a/src/FormHandlerInterface.php
+++ b/src/FormHandlerInterface.php
@@ -20,9 +20,9 @@ interface FormHandlerInterface
 {
     /**
      * @param FormFactoryInterface $factory The factory can be used to instantiate a form
-     * @param mixed[]              $options Any custom data to be used in creating the form (This can be form options, api values etc)
+     * @param Options              $options Any custom data to be used in creating the form (This can be form options, api values etc)
      *
      * @return string|FormInterface The form to use for this handler
      */
-    public function getForm(FormFactoryInterface $factory = null, ...$options);
+    public function getForm(FormFactoryInterface $factory, Options $options);
 }

--- a/src/FormHandlerOptionsResolver.php
+++ b/src/FormHandlerOptionsResolver.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the FormHandlerBundle project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2017
+ */
+
+namespace SolidWorx\FormHandler;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+interface FormHandlerOptionsResolver
+{
+    /**
+     * Configure defined, required and default options
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver): void;
+}

--- a/src/FormRequest.php
+++ b/src/FormRequest.php
@@ -43,9 +43,9 @@ class FormRequest
      * @param FormInterface $form
      * @param Request       $request
      * @param Response      $response
-     * @param array         $options
+     * @param Options       $options
      */
-    public function __construct(FormInterface $form = null, Request $request = null, Response $response = null, array $options = [])
+    public function __construct(FormInterface $form = null, Request $request = null, Response $response = null, Options $options = null)
     {
         $this->form = $form;
         $this->request = $request;
@@ -102,9 +102,9 @@ class FormRequest
     }
 
     /**
-     * @return array
+     * @return Options
      */
-    public function getOptions(): array
+    public function getOptions(): Options
     {
         return $this->options;
     }
@@ -112,8 +112,8 @@ class FormRequest
     /**
      * @param array $options
      */
-    public function setOptions(array $options): void
+    public function addOptions(array $options): void
     {
-        $this->options = $options;
+        $this->options = Options::fromArray($options)->merge($this->options);
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of the FormHandlerBundle project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2017
+ */
+
+namespace SolidWorx\FormHandler;
+
+class Options implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    private $options = [];
+
+    private function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Get a options, providing a default if the value doesn't exist
+     *
+     * @param string $key
+     * @param null   $default
+     *
+     * @return mixed|null
+     */
+    public function get(string $key, $default = null)
+    {
+        if (array_key_exists($key, $this->options)) {
+            return $this->options[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return Options
+     */
+    public static function fromArray(array $options): Options
+    {
+        return new self($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new \LogicException(__CLASS__." is immutable, you can't change it's values");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        throw new \LogicException(__CLASS__." is immutable, you can't change it's values");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->options);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return Options
+     */
+    public function merge(array $options)
+    {
+        return new self(array_merge_recursive($options, $this->options));
+    }
+}

--- a/src/Test/FormHandlerTestCase.php
+++ b/src/Test/FormHandlerTestCase.php
@@ -21,6 +21,7 @@ use SolidWorx\FormHandler\FormHandlerFailInterface;
 use SolidWorx\FormHandler\FormHandlerInterface;
 use SolidWorx\FormHandler\FormHandlerSuccessInterface;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
@@ -78,7 +79,7 @@ abstract class FormHandlerTestCase extends TestCase
             $formHandler->registerHandler($handler);
         }
 
-        $response = $formHandler->handle($handler, ...$this->getHandlerOptions());
+        $response = $formHandler->handle($handler, $this->getHandlerOptions());
 
         $this->assertResponse($response);
     }
@@ -120,7 +121,7 @@ abstract class FormHandlerTestCase extends TestCase
         $this->registerSuccessHandler($handler, $dispatcher);
         $this->registerFailHandler($handler, $dispatcher);
 
-        $formHandler->handle($handler, ...$this->getHandlerOptions());
+        $formHandler->handle($handler, $this->getHandlerOptions());
     }
 
     /**

--- a/tests/Decorator/FormCollectionDecoratorTest.php
+++ b/tests/Decorator/FormCollectionDecoratorTest.php
@@ -17,33 +17,41 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use SolidWorx\FormHandler\Decorator\FormCollectionDecorator;
 use SolidWorx\FormHandler\FormHandlerInterface;
+use SolidWorx\FormHandler\FormHandlerOptionsResolver;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use SolidWorx\FormHandler\Test\FormHandlerTestCase;
 use SolidWorx\FormHandler\Tests\Fixtures\Form\TestForm;
 use SolidWorx\FormHandler\Tests\Fixtures\Model\ChildClass;
 use SolidWorx\FormHandler\Tests\Fixtures\Model\TestClass;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormCollectionDecoratorTest extends FormHandlerTestCase
 {
     protected function getHandlerOptions(): array
     {
         return [
-            new TestClass,
+            'entity' => new TestClass,
         ];
     }
 
     public function getHandler()
     {
-        $handlerMock = new class implements FormHandlerInterface
+        $handlerMock = new class implements FormHandlerInterface, FormHandlerOptionsResolver
         {
-            public function getForm(FormFactoryInterface $factory = null, ...$options)
+            public function getForm(FormFactoryInterface $factory, Options $options)
             {
                 $class = new TestClass();
                 $class->child = [new ChildClass('value3')];
 
                 return $factory->create(TestForm::class, $class);
+            }
+
+            public function configureOptions(OptionsResolver $resolver): void
+            {
+                $resolver->setDefined('entity');
             }
         };
 

--- a/tests/Fixtures/TestFormHandler.php
+++ b/tests/Fixtures/TestFormHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SolidWorx\FormHandler\Tests\Fixtures;
 
 use SolidWorx\FormHandler\FormHandlerInterface;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -22,7 +23,7 @@ class TestFormHandler implements FormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm(FormFactoryInterface $factory = null, ...$options)
+    public function getForm(FormFactoryInterface $factory, Options $options)
     {
         return TextType::class;
     }

--- a/tests/Fixtures/TestFormHandlerWithFailHandlerInterface.php
+++ b/tests/Fixtures/TestFormHandlerWithFailHandlerInterface.php
@@ -16,13 +16,14 @@ namespace SolidWorx\FormHandler\Tests\Fixtures;
 use SolidWorx\FormHandler\FormHandlerFailInterface;
 use SolidWorx\FormHandler\FormHandlerInterface;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class TestFormHandlerWithFailHandlerInterface implements FormHandlerInterface, FormHandlerFailInterface
 {
-    public function getForm(FormFactoryInterface $factory = null, ...$options)
+    public function getForm(FormFactoryInterface $factory, Options $options)
     {
         /* noop */
     }

--- a/tests/Fixtures/TestFormHandlerWithResponse.php
+++ b/tests/Fixtures/TestFormHandlerWithResponse.php
@@ -16,12 +16,13 @@ namespace SolidWorx\FormHandler\Tests\Fixtures;
 use SolidWorx\FormHandler\FormHandlerInterface;
 use SolidWorx\FormHandler\FormHandlerResponseInterface;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class TestFormHandlerWithResponse implements FormHandlerInterface, FormHandlerResponseInterface
 {
-    public function getForm(FormFactoryInterface $factory = null, ...$options)
+    public function getForm(FormFactoryInterface $factory, Options $options)
     {
         /* noop */
     }

--- a/tests/Fixtures/TestFormHandlerWithSuccessHandlerInterface.php
+++ b/tests/Fixtures/TestFormHandlerWithSuccessHandlerInterface.php
@@ -16,12 +16,13 @@ namespace SolidWorx\FormHandler\Tests\Fixtures;
 use SolidWorx\FormHandler\FormHandlerInterface;
 use SolidWorx\FormHandler\FormHandlerSuccessInterface;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class TestFormHandlerWithSuccessHandlerInterface implements FormHandlerInterface, FormHandlerSuccessInterface
 {
-    public function getForm(FormFactoryInterface $factory = null, ...$options)
+    public function getForm(FormFactoryInterface $factory, Options $options)
     {
         /* noop */
     }

--- a/tests/Fixtures/TestFormHandlerWithSuccessHandlerThrowsExceptionInterface.php
+++ b/tests/Fixtures/TestFormHandlerWithSuccessHandlerThrowsExceptionInterface.php
@@ -16,12 +16,13 @@ namespace SolidWorx\FormHandler\Tests\Fixtures;
 use SolidWorx\FormHandler\FormHandlerInterface;
 use SolidWorx\FormHandler\FormHandlerSuccessInterface;
 use SolidWorx\FormHandler\FormRequest;
+use SolidWorx\FormHandler\Options;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class TestFormHandlerWithSuccessHandlerThrowsExceptionInterface implements FormHandlerInterface, FormHandlerSuccessInterface
 {
-    public function getForm(FormFactoryInterface $factory = null, ...$options)
+    public function getForm(FormFactoryInterface $factory, Options $options)
     {
         /* noop */
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the FormHandlerBundle project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2017
+ */
+
+namespace SolidWorx\FormHandler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SolidWorx\FormHandler\Options;
+
+class OptionsTest extends TestCase
+{
+    public function testGet()
+    {
+        $options = Options::fromArray(['a' => 'b']);
+
+        $this->assertSame('b', $options->get('a'));
+        $this->assertSame('b', $options['a']);
+    }
+
+    public function testGetWithDefault()
+    {
+        $options = Options::fromArray(['a' => 'b']);
+
+        $this->assertNull($options->get('c'));
+        $this->assertNull($options['c']);
+    }
+
+    public function testMutable()
+    {
+        $options = Options::fromArray(['a' => 'b']);
+
+        $this->expectException(\LogicException::class);
+
+        $options['c'] = 'd';
+    }
+
+    public function testMerge()
+    {
+        $options = Options::fromArray(['a' => 'b'])->merge(['c' => 'd']);
+
+        $this->assertSame('b', $options->get('a'));
+        $this->assertSame('b', $options['a']);
+        $this->assertSame('d', $options->get('c'));
+        $this->assertSame('d', $options['c']);
+    }
+}


### PR DESCRIPTION
Create a `Options` class to manage all the options passed to a form.
This makes the `getForm` cleaner and more reliable where you don't have to guess magic index numbers.
Also add the option to define the valid options that can be passed to a handler by using the Symfony OptionsResolver component

**Note:** This breaks BC since the signature of the `FormHandlerInterface::getForm` method changes